### PR TITLE
imp(ios): Add script to run example on ios

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ You can test your changes by installing `example` app on a simulator or device:
 
 Installing on a iOS:
 
+- Run `yarn ios`
+
+or
+
 - Open `example/ios/example.xcodeproj`
 - Click `run` in the top left corner of `Xcode`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ All work on React Native ART happens directly on GitHub. Contributors send pull 
 
 You can test your changes by installing `example` app on a simulator or device:
 
-Installing on a iOS:
+Installing on iOS:
 
 - Run `yarn ios`
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android --root example",
+    "ios": "react-native run-ios --project-path example/ios --scheme example",
     "flow-check": "flow check",
     "lint": "eslint . --cache"
   },


### PR DESCRIPTION
# Summary

Add yarn script to build and open example app on iOS and update `CONTRIBUTING.md`.

To run app on iOS you can execute `yarn ios`.

## Test Plan

Example app is build correctly.

## Checklist

- [x] I have tested this on a device and a simulator

Fixes: #10 