### PR TITLE
Exclude build folders from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 .circleci
 .github
 example
+android/build
+ios/build


### PR DESCRIPTION
# Summary

The build folders are not needed and make the local Android builds fail because of symbolic links which link to files in the publisher's filesystem and therefore don't exist on the host computer.

The following error is raised:
```
Could not list contents of '/Users/username/app/node_modules/@react-native-community/art/ios/build/ART/ModuleCache.noindex/3GDSN6BS5CMUT/QuartzCore-23I9VTX2KZMTH.pcm.lock'. Couldn't follow symbolic link.
```
Example of failing links (kacper is not my username 😅):
```
ios/build/ART/ModuleCache.noindex/3GDSN6BS5CMUT/QuartzCore-23I9VTX2KZMTH.pcm.lock -> /Users/kacper/projects/oss/art/ios/build/ART/ModuleCache.noindex/3GDSN6BS5CMUT/QuartzCore-23I9VTX2KZMTH.pcm.lock-df1effe1
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Nothing

### What are the steps to reproduce (after prerequisites)?
- Android release build with RN 0.60+

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
