### PR TITLE
fix: pass the right number of arguments to Transform.prototype.scale

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -57,7 +57,7 @@ export function extractTransform(props: TransformProps): Array<number> {
     .transformTo(1, 0, 0, 1, 0, 0)
     .move(props.x || 0, props.y || 0)
     .rotate(props.rotation || 0, props.originX, props.originY)
-    .scale(scaleX, scaleY, props.originX, props.originY);
+    .scale(scaleX, scaleY);
 
   if (props.transform != null) {
     pooledTransform.transform(props.transform);


### PR DESCRIPTION
The `scale` method only takes 2 arguments, but we're passing it 4.