### PR TITLE
fix: extractOpacity bug when "visible" is undefined

### DIFF
--- a/lib/__tests__/helpers.test.js
+++ b/lib/__tests__/helpers.test.js
@@ -19,14 +19,15 @@ describe('testing childrenAsString function', () => {
 });
 
 describe('testing extractOpacity function', () => {
-  it('returns 0 if visible is false or null', () => {
+  it('returns 0 if visible is false', () => {
     expect(extractOpacity({visible: false})).toBe(0);
     expect(extractOpacity({visible: false, opacity: 1})).toBe(0);
     expect(extractOpacity({visible: false, opacity: 0.5})).toBe(0);
   });
 
-  it('returns opacity if visible is true', () => {
+  it('returns opacity if visible is true or undefined', () => {
     expect(extractOpacity({visible: true, opacity: 0.5})).toBe(0.5);
+    expect(extractOpacity({opacity: 0.5})).toBe(0.5);
   });
 });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,7 +36,7 @@ export function childrenAsString(children?: string | Array<string>) {
 
 export function extractOpacity({visible, opacity}: OpacityProps) {
   // TODO: visible === false should also have no hit detection
-  if (!visible || visible === false) {
+  if (visible === false) {
     return 0;
   }
   if (opacity == null) {


### PR DESCRIPTION
When the `visible` prop is undefined, the `extractOpacity` function should ignore it.

Instead of changing the `!visible` check to `visible === null`, I removed it because `visible: null` is ambiguous, so `visible: false` should always be preferred.