### PR TITLE
fix(helpers.js): adds platform check to extractColor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@react-native-community'],
+  env: {
+    jest: true
+  }
 };

--- a/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java
+++ b/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java
@@ -51,7 +51,7 @@ public class ARTShapeShadowNode extends ARTVirtualNode {
   private static final int COLOR_TYPE_PATTERN = 3;
 
   protected @Nullable Path mPath;
-  private @Nullable float[] mStrokeColor;
+  private @Nullable String mStrokeColor;
   private @Nullable float[] mBrushData;
   private @Nullable float[] mStrokeDash;
   private float mStrokeWidth = 1;
@@ -68,8 +68,8 @@ public class ARTShapeShadowNode extends ARTVirtualNode {
   }
 
   @ReactProp(name = "stroke")
-  public void setStroke(@Nullable ReadableArray strokeColors) {
-    mStrokeColor = PropHelper.toFloatArray(strokeColors);
+  public void setStroke(@Nullable String strokeColors) {
+    mStrokeColor = strokeColors;
     markUpdated();
   }
 
@@ -128,7 +128,7 @@ public class ARTShapeShadowNode extends ARTVirtualNode {
    * if the stroke should be drawn, {@code false} if not.
    */
   protected boolean setupStrokePaint(Paint paint, float opacity) {
-    if (mStrokeWidth == 0 || mStrokeColor == null || mStrokeColor.length == 0) {
+    if (mStrokeWidth == 0 || mStrokeColor == null) {
       return false;
     }
     paint.reset();
@@ -163,11 +163,7 @@ public class ARTShapeShadowNode extends ARTVirtualNode {
             "strokeJoin " + mStrokeJoin + " unrecognized");
     }
     paint.setStrokeWidth(mStrokeWidth * mScale);
-    paint.setARGB(
-        (int) (mStrokeColor.length > 3 ? mStrokeColor[3] * opacity * 255 : opacity * 255),
-        (int) (mStrokeColor[0] * 255),
-        (int) (mStrokeColor[1] * 255),
-        (int) (mStrokeColor[2] * 255));
+    paint.setColor(Color.parseColor(mStrokeColor));
     if (mStrokeDash != null && mStrokeDash.length > 0) {
       paint.setPathEffect(new DashPathEffect(mStrokeDash, 0));
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  setupFilesAfterEnv: ['<rootDir>/jest.mock.js'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   preset: 'react-native',
-  setupFilesAfterEnv: ['<rootDir>/jest.mock.js'],
 };

--- a/jest.mock.js
+++ b/jest.mock.js
@@ -1,1 +1,0 @@
-jest.mock('Platform', () => {});

--- a/jest.mock.js
+++ b/jest.mock.js
@@ -1,1 +1,1 @@
-jest.mock('Platform', () => {})
+jest.mock('Platform', () => {});

--- a/jest.mock.js
+++ b/jest.mock.js
@@ -1,0 +1,1 @@
+jest.mock('Platform', () => {})

--- a/lib/__tests__/helpers.test.js
+++ b/lib/__tests__/helpers.test.js
@@ -19,14 +19,15 @@ describe('testing childrenAsString function', () => {
 });
 
 describe('testing extractOpacity function', () => {
-  it('returns 0 if visible is false or null', () => {
+  it('returns 0 if visible is false', () => {
     expect(extractOpacity({visible: false})).toBe(0);
     expect(extractOpacity({visible: false, opacity: 1})).toBe(0);
     expect(extractOpacity({visible: false, opacity: 0.5})).toBe(0);
   });
 
-  it('returns opacity if visible is true', () => {
+  it('returns opacity if visible is true or undefined', () => {
     expect(extractOpacity({visible: true, opacity: 0.5})).toBe(0.5);
+    expect(extractOpacity({opacity: 0.5})).toBe(0.5);
   });
 });
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,7 +36,7 @@ export function childrenAsString(children?: string | Array<string>) {
 
 export function extractOpacity({visible, opacity}: OpacityProps) {
   // TODO: visible === false should also have no hit detection
-  if (!visible || visible === false) {
+  if (visible === false) {
     return 0;
   }
   if (opacity == null) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,17 +10,16 @@
 import Color from 'art/core/color';
 import Transform from 'art/core/transform';
 import type {
-  OpacityProps,
-  TransformProps,
-  ColorType,
-  StrokeJoin,
-  StrokeCap,
-  Brush,
   Alignment,
+  Brush,
+  ColorType,
   Font,
   GradientStops,
+  OpacityProps,
+  StrokeCap,
+  StrokeJoin,
+  TransformProps,
 } from './types';
-import {Platform} from 'react-native';
 
 export function childrenAsString(children?: string | Array<string>) {
   if (!children) {
@@ -78,11 +77,8 @@ export function extractColor(color?: ColorType) {
   if (color == null) {
     return null;
   }
-  if (Platform.OS === 'ios') {
-    return color;
-  }
   const c = new Color(color);
-  return [c.red / 255, c.green / 255, c.blue / 255, c.alpha];
+  return c.toHEX();
 }
 
 export function extractStrokeJoin(strokeJoin?: StrokeJoin) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Stroke is not applied to Shapes on iOS. Works correctly for Android. After doing some debugging, figured out when we pass an array value for color, the prop is completely ignored by RN. Only valid values are string and number. The same solution doesn't work with Android. In android it is expecting an array. Thus adding a platform check in helper.js

P.S. If I import from ReactNativeArt.js, array value for color works for iOS and Android both. 
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

#30 

* What is the feature? (if applicable)
* How did you implement the solution?
Adds Platform check to extractColor

* What areas of the library does it impact?
helpers.js
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
