### PR TITLE
fix warning incorrect peer dependency "react-native@^0.59.9"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ npm install @react-native-community/art --save
 
 If using React Native >= 0.60, add the React-ART pod to your Podfile in ios folder:
 
+```js
 pod 'ReactNativeART', :path => '../node_modules/@react-native-community/art'
+```
 
 Remember to run pod install after these changes.
 
 Android does not needed any actions.
 
-If using React Native <= 0.59
+If using React Native <= 0.59, run in terminal:
 
 ```js
 react-native link @react-native-community/art

--- a/README.md
+++ b/README.md
@@ -24,10 +24,19 @@ npm install @react-native-community/art --save
 
 ### Mostly automatic linking
 
+If using React Native >= 0.60, add the React-ART pod to your Podfile in ios folder:
+
+pod 'ReactNativeART', :path => '../node_modules/@react-native-community/art'
+
+Remember to run pod install after these changes.
+
+Android does not needed any actions.
+
+If using React Native <= 0.59
+
 ```js
 react-native link @react-native-community/art
 ```
-
 ### Manual linking
 
 <details>

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
-    "react-native": "^0.59.9"
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
# Summary

Fix the warning, issue https://github.com/react-native-community/art/issues/33
`warning " > @react-native-community/art@1.0.1" has incorrect peer dependency "react-native@^0.59.9".`

Fix blank screen, instead of the ART graph on android. 

**Environment info**
    "react": "16.9.0",
    "react-native": "0.61.2",
    "@react-native-community/art": "1.0.1"

## Test Plan

Android works good

### What's required for testing (prerequisites)?

IOS still has blank screen instead ART component, but I suppose the reason is in something else (not  in the peer dependency)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
