### PR TITLE
Fix manual android installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ project(':react-native-art').projectDir = new File(rootProject.projectDir, '../n
 ```groovy
 dependencies {
    ...
-   implementation project(':react-native-art')
+   implementation project(':@react-native-community_art')
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The documentation for manually installing on Android gives compilation error
> A problem occurred evaluating project ':app'.
> Project with path ':react-native-art' could not be found in project ':app'.

Whereas the project path should be `:@react-native-community_art'`
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I added the documentation in `README.md`
