### PR TITLE
Proposal: add setNativeProps to Group, Shape, Text

### DIFF
--- a/lib/Group.js
+++ b/lib/Group.js
@@ -11,31 +11,45 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
 import {NativeGroup} from './nativeComponents';
-import {extractOpacity, extractTransform} from './helpers';
+import {translatePropsToNativeProps} from './helpers';
 import type {OpacityProps, TransformProps} from './types';
 
-type GroupProps = OpacityProps &
+export type GroupProps = OpacityProps &
   TransformProps & {
     children: React.Node,
   };
+
+const nativePropList = ['opacity', 'transform'];
 
 export default class Group extends React.Component<GroupProps> {
   static contextTypes = {
     isInSurface: PropTypes.bool.isRequired,
   };
 
+  _rootComponent = null;
+
+  setNativeProps(newProps: $Shape<GroupProps>) {
+    if (this._rootComponent && newProps) {
+      // newProps will only include what is changed, but we need existing props for some translations:
+      const nativeProps = translatePropsToNativeProps(
+        ({
+          ...this.props,
+          ...newProps,
+        }: GroupProps),
+        nativePropList,
+      );
+      // $FlowFixMe
+      this._rootComponent.setNativeProps(nativeProps);
+    }
+  }
+
   render() {
     invariant(
       this.context.isInSurface,
       'ART: <Group /> must be a child of a <Surface />',
     );
+    const nativeProps = translatePropsToNativeProps(this.props, nativePropList);
 
-    return (
-      <NativeGroup
-        opacity={extractOpacity(this.props)}
-        transform={extractTransform(this.props)}>
-        {this.props.children}
-      </NativeGroup>
-    );
+    return <NativeGroup {...nativeProps}>{this.props.children}</NativeGroup>;
   }
 }

--- a/lib/Shape.js
+++ b/lib/Shape.js
@@ -10,15 +10,7 @@
 import * as React from 'react';
 import {NativeShape} from './nativeComponents';
 import Path from './ARTSerializablePath';
-import {
-  extractTransform,
-  extractOpacity,
-  childrenAsString,
-  extractColor,
-  extractStrokeJoin,
-  extractStrokeCap,
-  extractBrush,
-} from './helpers';
+import {translatePropsToNativeProps} from './helpers';
 import type {
   TransformProps,
   OpacityProps,
@@ -42,6 +34,18 @@ export type ShapeProps = TransformProps &
     height: number,
   };
 
+const nativePropList = [
+  'd',
+  'fill',
+  'opacity',
+  'stroke',
+  'strokeCap',
+  'strokeDash',
+  'strokeJoin',
+  'strokeWidth',
+  'transform',
+];
+
 export default class Shape extends React.Component<ShapeProps> {
   static defaultProps = {
     strokeWidth: 1,
@@ -49,22 +53,30 @@ export default class Shape extends React.Component<ShapeProps> {
     height: 0,
   };
 
+  _rootComponent = null;
+
+  setNativeProps(newProps: $Shape<ShapeProps>) {
+    if (this._rootComponent && newProps) {
+      // newProps will only include what is changed, but we need existing props for some translations:
+      const nativeProps = translatePropsToNativeProps(
+        ({
+          ...this.props,
+          ...newProps,
+        }: ShapeProps),
+        nativePropList,
+      );
+      // $FlowFixMe
+      this._rootComponent.setNativeProps(nativeProps);
+    }
+  }
+
   render() {
-    const props = this.props;
-    const path = props.d || childrenAsString(props.children);
-    const d = (path instanceof Path ? path : new Path(path)).toJSON();
+    const nativeProps = translatePropsToNativeProps(this.props, nativePropList);
 
     return (
       <NativeShape
-        fill={extractBrush(props.fill, props)}
-        opacity={extractOpacity(props)}
-        stroke={extractColor(props.stroke)}
-        strokeCap={extractStrokeCap(props.strokeCap)}
-        strokeDash={props.strokeDash || null}
-        strokeJoin={extractStrokeJoin(props.strokeJoin)}
-        strokeWidth={props.strokeWidth}
-        transform={extractTransform(props)}
-        d={d}
+        ref={component => (this._rootComponent = component)}
+        {...nativeProps}
       />
     );
   }

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -10,17 +10,7 @@
 import * as React from 'react';
 import Path from './ARTSerializablePath';
 import {NativeText} from './nativeComponents';
-import {
-  extractBrush,
-  extractOpacity,
-  extractColor,
-  extractStrokeCap,
-  extractStrokeJoin,
-  extractTransform,
-  extractAlignment,
-  childrenAsString,
-  extractFontAndLines,
-} from './helpers';
+import {translatePropsToNativeProps} from './helpers';
 import type {
   TransformProps,
   OpacityProps,
@@ -47,6 +37,20 @@ export type TextProps = TransformProps &
     path?: string | Path,
   };
 
+const nativePropList = [
+  'alignment',
+  'frame',
+  'fill',
+  'opacity',
+  'path',
+  'stroke',
+  'strokeCap',
+  'strokeDash',
+  'strokeJoin',
+  'strokeWidth',
+  'transform',
+];
+
 export default class Text extends React.Component<TextProps> {
   static defaultProps = {
     strokeWidth: 1,
@@ -54,29 +58,30 @@ export default class Text extends React.Component<TextProps> {
     height: 0,
   };
 
+  _rootComponent = null;
+
+  setNativeProps(newProps: $Shape<TextProps>) {
+    if (this._rootComponent && newProps) {
+      // newProps will only include what is changed, but we need existing props for some translations:
+      const nativeProps = translatePropsToNativeProps(
+        ({
+          ...this.props,
+          ...newProps,
+        }: TextProps),
+        nativePropList,
+      );
+      // $FlowFixMe
+      this._rootComponent.setNativeProps(nativeProps);
+    }
+  }
+
   render() {
-    const props = this.props;
-    const path = props.path;
-    const textPath = path
-      ? (path instanceof Path ? path : new Path(path)).toJSON()
-      : null;
-    const textFrame = extractFontAndLines(
-      props.font,
-      childrenAsString(props.children),
-    );
+    const nativeProps = translatePropsToNativeProps(this.props, nativePropList);
+
     return (
       <NativeText
-        fill={extractBrush(props.fill, props)}
-        opacity={extractOpacity(props)}
-        stroke={extractColor(props.stroke)}
-        strokeCap={extractStrokeCap(props.strokeCap)}
-        strokeDash={props.strokeDash || null}
-        strokeJoin={extractStrokeJoin(props.strokeJoin)}
-        strokeWidth={props.strokeWidth}
-        transform={extractTransform(props)}
-        alignment={extractAlignment(props.alignment)}
-        frame={textFrame}
-        path={textPath}
+        ref={component => (this._rootComponent = component)}
+        {...nativeProps}
       />
     );
   }

--- a/lib/__tests__/helpers.test.js
+++ b/lib/__tests__/helpers.test.js
@@ -6,6 +6,7 @@ import {
   extractStrokeJoin,
   extractStrokeCap,
   extractAlignment,
+  translatePropsToNativeProps,
 } from '../helpers';
 
 describe('testing childrenAsString function', () => {
@@ -76,5 +77,74 @@ describe('testing extractAlignment', () => {
 
   it('default to left', () => {
     expect(extractAlignment()).toBe(LEFT);
+  });
+});
+
+describe('testing translatePropsToNativeProps', () => {
+  it('returns correct data for each prop', () => {
+    // asserting the values in the returned object will fail if any of our helpers
+    // are changed, but this is required to ensure the correct arguments are passed to
+    // each of them at the right key:
+    const props = {
+      alignment: 'center',
+      d: 'M 10,30 A 20,20 z',
+      fill: '#D9003A',
+      font: 'trebuchet',
+      height: 100,
+      opacity: 0.5,
+      stroke: '#2DCD71',
+      strokeCap: 'butt',
+      strokeDash: 2,
+      strokeJoin: 'miter',
+      strokeWidth: 3,
+      scale: 1.1,
+      width: 200,
+    };
+    const nativeProps1 = translatePropsToNativeProps(props, [
+      'alignment',
+      'd',
+      'fill',
+      'frame',
+      'opacity',
+      'stroke',
+      'strokeCap',
+      'strokeDash',
+      'strokeJoin',
+      'strokeWidth',
+      'transform',
+    ]);
+    expect(nativeProps1).toEqual({
+      alignment: 2,
+      d: [0, 10, 30],
+      fill: [0, 0.8509803921568627, 0, 0.22745098039215686, 1],
+      frame: {
+        font: {
+          fontFamily: 'trebuchet',
+          fontSize: 12,
+          fontStyle: 'normal',
+          fontWeight: 'normal',
+        },
+        lines: [''],
+      },
+      opacity: 0.5,
+      stroke: '#2dcd71',
+      strokeCap: 0,
+      strokeDash: 2,
+      strokeJoin: 0,
+      strokeWidth: 3,
+      transform: [1.1, 0, 0, 1.1, 0, 0],
+    });
+
+    // test that we can select only a subset of nativeProps:
+    const nativeProps2 = translatePropsToNativeProps(props, [
+      'fill',
+      'opacity',
+      'stroke',
+    ]);
+    expect(nativeProps2).toEqual({
+      fill: [0, 0.8509803921568627, 0, 0.22745098039215686, 1],
+      opacity: 0.5,
+      stroke: '#2dcd71',
+    });
   });
 });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,6 +20,10 @@ import type {
   StrokeJoin,
   TransformProps,
 } from './types';
+import Path from './ARTSerializablePath';
+import type {ShapeProps} from './Shape';
+import type {GroupProps} from './Group';
+import type {TextProps} from './Text';
 
 export function childrenAsString(children?: string | Array<string>) {
   if (!children) {
@@ -310,4 +314,56 @@ export function insertDoubleColorStopsIntoArray(
   lastIndex = insertColorsIntoArray(stops, targetArray, lastIndex);
   lastIndex = insertOffsetsIntoArray(stops, targetArray, lastIndex, 0.5, false);
   insertOffsetsIntoArray(stops, targetArray, lastIndex, 0.5, true);
+}
+
+// a lookup of the methods we use to translate props to native props
+export const propsToNativePropsTranslations = {
+  alignment: ({alignment}: {alignment: Alignment}) =>
+    extractAlignment(alignment),
+  d: ({children, d}: {children?: string | Array<string>, d: string | Path}) => {
+    const path = d || childrenAsString(children);
+    return (path instanceof Path ? path : new Path(path)).toJSON();
+  },
+  fill: ({
+    fill,
+    height,
+    width,
+  }: {
+    fill?: Brush | string,
+    height: number,
+    width: number,
+  }) => extractBrush(fill, {height, width}),
+  frame: ({
+    children,
+    font,
+  }: {
+    children?: string | Array<string>,
+    font?: string | Font,
+  }) => extractFontAndLines(font, childrenAsString(children)),
+  opacity: extractOpacity,
+  stroke: ({stroke}: {stroke: ColorType}) => extractColor(stroke),
+  strokeCap: ({strokeCap}: {strokeCap: StrokeCap}) =>
+    extractStrokeCap(strokeCap),
+  strokeDash: ({strokeDash}: {strokeDash: Array<number>}) => strokeDash || null,
+  strokeJoin: ({strokeJoin}: {strokeJoin: StrokeJoin}) =>
+    extractStrokeJoin(strokeJoin),
+  strokeWidth: ({strokeWidth}: {strokeWidth: number}) => strokeWidth,
+  transform: extractTransform,
+  path: ({path}: {path: string | Path}) =>
+    path ? (path instanceof Path ? path : new Path(path)).toJSON() : null,
+};
+
+// take props, and an array of the required nativeProps, and return an object with
+// values for those nativeProps
+export function translatePropsToNativeProps(
+  props: GroupProps | ShapeProps | TextProps,
+  requiredProps: Array<string>,
+) {
+  return requiredProps.reduce(
+    (nativeProps, prop) => ({
+      ...nativeProps,
+      [prop]: propsToNativePropsTranslations[prop](props),
+    }),
+    {},
+  );
 }


### PR DESCRIPTION
# Summary

This PR adds setNativeProps methods to the `<Group/>`, `<Shape/>`, and `<Text/>` components provided by art to allow direct manipulation of the native component, as per https://facebook.github.io/react-native/docs/direct-manipulation.

A benefit of this change is that we can use `Animated.Value`s to animate props like opacity without the animation calling the render method each frame (currently `forceUpdate` is fired to update the component, causing a rerender).  

My personal motivation is to use react-native-reanimated with art, which requires this change to work, but I believe it has value more generally.

Notes/discussion points:
- I've created a method to translate props to native props, and used this both in the `render` and `setNativeProps` methods for each component.  This may differ from what a user would expect, where `setNativeProps` suggests passing its arguments straight to the native component.  I've done this because I think most users are going to want to set props in the render method, and then directly manipulate them in a consistent manner, relying on art to translate the props to what the native component requires.  If we were to pass the arguments directly through, many of them would need to be a different format to their equivalent prop, which I think adds unnecessary complexity
- for each component, `setNativeProps` merges existing props into the new props before translation.  The method we use does provide for only translating the props that would change as a result of the new props passed in (we pass an array of the props required to be translated), but I suspect the logic to work out what those props would be would be as expensive to compute as the 'over computing' we are undertaking by translating all props, every time.


## Test Plan

I've tested (on iOS simulator, Android emulator and real iPhone 8) that:
- the components render correctly, as they did before the change (no detrimental impact)
- using an Animated.Value for opacity, strokeWidth, stroke, and fill will correctly animate the `<Shape/>` component without firing the render method


### What's required for testing (prerequisites)?

- I guess we should probably test on a real android device?

### What are the steps to reproduce (after prerequisites)?

- N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |       ✅     |
| Android |    ✅ - emulator tested only     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator (not android device)
- [ N/A] I added the documentation in `README.md`
- [X ] I mentioned this change in `CHANGELOG.md`
- [X ] I updated the typed files (TS and Flow)
- [N/A ] I added a sample use of the API in the example project (`example/App.js`)