### PR TITLE
Copy types from DefinitelyTyped into index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,63 @@
+declare module '@react-native-community/art' {
+  import {ViewStyle, StyleProp} from 'react-native';
+  import React from 'react';
+
+  export interface ARTNodeMixin {
+    opacity?: number;
+    originX?: number;
+    originY?: number;
+    scaleX?: number;
+    scaleY?: number;
+    scale?: number;
+    title?: string;
+    x?: number;
+    y?: number;
+    visible?: boolean;
+  }
+
+  export interface ARTGroupProps extends ARTNodeMixin {
+    width?: number;
+    height?: number;
+  }
+
+  export interface ARTClippingRectangleProps extends ARTNodeMixin {
+    width?: number;
+    height?: number;
+  }
+
+  export interface ARTRenderableMixin extends ARTNodeMixin {
+    fill?: string;
+    stroke?: string;
+    strokeCap?: 'butt' | 'square' | 'round';
+    strokeDash?: number[];
+    strokeJoin?: 'bevel' | 'miter' | 'round';
+    strokeWidth?: number;
+  }
+
+  export interface ARTShapeProps extends ARTRenderableMixin {
+    d: string;
+    width?: number;
+    height?: number;
+  }
+
+  export interface ARTTextProps extends ARTRenderableMixin {
+    font?: string;
+    alignment?: string;
+  }
+
+  export interface ARTSurfaceProps {
+    style?: StyleProp<ViewStyle>;
+    width: number;
+    height: number;
+  }
+
+  export class ClippingRectangle extends React.Component<ARTClippingRectangleProps> {}
+
+  export class Group extends React.Component<ARTGroupProps> {}
+
+  export class Shape extends React.Component<ARTShapeProps> {}
+
+  export class Surface extends React.Component<ARTSurfaceProps> {}
+
+  export class Text extends React.Component<ARTTextProps> {}
+}


### PR DESCRIPTION
# Summary

- Add in the TypeScript types from DefinitelyTyped.
- (But omit the ARTStatic type because the documentation for `@types/react-native-community/art` doesn't mention a default export anywhere, and change the name 'ARTText' to just 'Text' to match the exports.)
- Fix issue #12 

## Test Plan

Clone and run a test project which uses TypeScript and ART:

- `git clone https://github.com/richardbarrell-calvium/ReactNativeArtTypescriptTest.git`
- `cd ReactNativeArtTypescriptTest`
- `yarn`
- `(cd ios; pod install)`
- `react-native run-ios`
- `react-native run-android`

Verify that tsc passes:

- `yarn tsc`

Introduce a type error and verify that tsc no longer passes:

- Edit `App.tsx`, replace `strokeWidth={2}` with `strokeWidth="2"`
- `yarn tsc`
- Verify that it fails with a type error like "Type 'string' is not assignable to type 'number | undefined"

### What's required for testing (prerequisites)?

- `node`
- `yarn`
- Xcode
- Android SDK

### What are the steps to reproduce (after prerequisites)?

- Create a new project with react-native and typescript
- `yarn add @react-native-community/art`
- Add a line `import {Surface} from '@react-native-community/art'` to a typescript source file
- `yarn tsc`
- TypeScript prints an unhappy message about there not being any types for the art module.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` - skipped because taking advantage of the TS types is transparent
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`) - skipped because the example project does not use TypeScript