### PR TITLE
fix: lib compatible with latest RN

### DIFF
--- a/lib/ClippingRectangle.js
+++ b/lib/ClippingRectangle.js
@@ -8,7 +8,6 @@
  */
 
 import * as React from 'react';
-import merge from 'react-native/Libraries/vendor/core/merge';
 import {extractOpacity, extractTransform, extractShadow} from './helpers';
 import {NativeGroup} from './nativeComponents';
 import type {OpacityProps, TransformProps, ShadowProps} from './types';
@@ -40,7 +39,8 @@ export default class ClippingRectangle extends React.Component<ClippingRectangle
     ];
 
     // The current clipping API requires x and y to be ignored in the transform
-    const {x, y, ...propsExcludingXAndY} = merge(this.props);
+    // $FlowFixMe
+    const {x, y, ...propsExcludingXAndY} = this.props;
 
     return (
       <NativeGroup


### PR DESCRIPTION
# Summary

Fixes #48 

`merge` method was removed from `RN` and it seems like it was unnecessary here (https://github.com/facebook/react-native/blob/0.61-stable/Libraries/vendor/core/merge.js).
