### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "react-native-community",
     "art"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/react-native-community/art.git",
+    "baseUrl": "https://github.com/react-native-community/art"
+  },
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "android": "react-native run-android --root example",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@react-native-community/art",
   "version": "1.2.0",
   "license": "MIT",
-  "author": "@react-native-community",
-  "homepage": "https://github.com/react-native-community/react-native-art",
+  "author": "react-native-art",
+  "homepage": "https://github.com/react-native-art/react-native-art",
   "description": "React Native module that allows you to draw vector graphics",
   "main": "./lib/index.js",
   "keywords": [
@@ -15,8 +15,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/react-native-community/art.git",
-    "baseUrl": "https://github.com/react-native-community/art"
+    "url": "git+https://github.com/react-native-art/art.git",
+    "baseUrl": "https://github.com/react-native-art/art"
   },
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
# Summary

This adds the `repository` property to the package.json. 

One problem with having no repository property is, that tools like license crawlers cannot read the creator and add repository links.

<img src="https://user-images.githubusercontent.com/15199031/92241115-fe3f1c80-eebd-11ea-8eb8-8252ed042b52.png" width="50%">

> See how the author is `???` and the **View Repository** button is not present?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
