### PR TITLE
fix(ios): Xcode12 build run on device crash

### DIFF
--- a/ios/ARTNode.m
+++ b/ios/ARTNode.m
@@ -8,6 +8,7 @@
 #import "ARTNode.h"
 
 #import "ARTContainer.h"
+#import "RCTConvert+ART.h"
 
 @implementation ARTNode
 
@@ -79,7 +80,9 @@
   CGContextSaveGState(context);
   CGContextConcatCTM(context, self.transform);
   CGContextSetAlpha(context, self.opacity);
-  CGContextSetShadowWithColor(context, self.shadow.offset, self.shadow.blur, self.shadow.color.CGColor);
+  UIColor *color = [UIColor colorWithCGColor:[RCTConvert CGColor:@(self.shadow.color)]];
+  color = [color colorWithAlphaComponent:self.shadow.alpha];
+  CGContextSetShadowWithColor(context, self.shadow.offset, self.shadow.blur, color.CGColor);
 }
 
 - (void)renderLayerTo:(CGContextRef)context

--- a/ios/ARTShadow.h
+++ b/ios/ARTShadow.h
@@ -8,5 +8,6 @@
 typedef struct {
   CGSize offset;
   CGFloat blur;
-  UIColor* color;
+  CGFloat alpha;
+  CGFloat color;
 } ARTShadow;

--- a/ios/RCTConvert+ART.m
+++ b/ios/RCTConvert+ART.m
@@ -164,12 +164,9 @@ RCT_ENUM_CONVERTER(CTTextAlignment, (@{
 + (ARTShadow)ARTShadow:(id)json
 {
   NSArray *arr = [self NSArray:json];
-  
-  UIColor *color = [UIColor colorWithCGColor:[self CGColor:[arr objectAtIndex:0]]];
-  color = [color colorWithAlphaComponent:[[arr objectAtIndex:1] floatValue]];
-  
   return (ARTShadow){
-    .color = color,
+    .color = [[arr objectAtIndex:0] doubleValue],
+    .alpha = [[arr objectAtIndex:1] floatValue],
     .blur = [[arr objectAtIndex:2] floatValue],
     .offset = (CGSize){
       .width = [[arr objectAtIndex:3] floatValue],


### PR DESCRIPTION
# Summary
Fixing the issues outlined in [#29721](https://github.com/facebook/react-native/issues/29721)

![20200919105840](https://user-images.githubusercontent.com/11879527/93669619-0d31eb80-fac8-11ea-908c-33587d79f538.jpg)

## Reason
Since the ARTShadow structure holds a color object, it will cause a zombie object after destruction.

## Test Plan

Ran the example project

### What's required for testing (prerequisites)?

- Xcode 12

### What are the steps to reproduce (after prerequisites)?

- Build and run the example project

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator